### PR TITLE
Fix minor typo in javascript.md

### DIFF
--- a/docs/embed/javascript.md
+++ b/docs/embed/javascript.md
@@ -27,7 +27,7 @@ or use the latest version hosted on jsDelivr:
 
 ## Getting Started
 
-The simplest way to get started is the pass a DOM element to our embed that will be used as container. By default, this one will completely fit its container:
+The simplest way to get started is to pass a DOM element to our embed that will be used as container. By default, this one will completely fit its container:
 
 ```html
 <div id="embed-container"></div>


### PR DESCRIPTION
The simplest way to get started is THE pass a DOM element to our embed , changed to -> The simplest way to get started is TO pass a DOM element to our embed